### PR TITLE
feat: add session-start update mechanism

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,17 +7,18 @@ Do not import local drivers directly for ordinary agent work.
 
 ## Load Order
 
-1. Decide the target platform before acting.
-2. For Android work, read `platforms/android/GUIDE.md`.
-3. For iOS work, read `platforms/ios/GUIDE.md`.
-4. Do not load all files.
-5. When the foreground app id is known, read only that app card if it exists:
+1. Update the harness once per session, before platform work: run `git -C <harness-root> pull --ff-only`, where `<harness-root>` is the directory containing this `AGENTS.md`. If offline, continue with the current version. On any other failure, read `UPDATE.md`.
+2. Decide the target platform before acting.
+3. For Android work, read `platforms/android/GUIDE.md`.
+4. For iOS work, read `platforms/ios/GUIDE.md`.
+5. Do not load all files.
+6. When the foreground app id is known, read only that app card if it exists:
    - Android: `apps/android/<package>/CARD.md`
    - iOS: `apps/ios/<bundle-id>/CARD.md`
-6. Read platform recovery only after a control, setup, state, or connectivity failure.
-7. Read the credentials guide under `core/credentials` when a screen asks for login, API keys, OTP, 2FA, payment, passcode, or other secrets.
-8. Write to `credentials/<app-id>.md` only when the user explicitly asks for local credential files.
-9. Read `core/memory/GUIDE.md` before reading or writing files under `memory/`.
+7. Read platform recovery only after a control, setup, state, or connectivity failure.
+8. Read the credentials guide under `core/credentials` when a screen asks for login, API keys, OTP, 2FA, payment, passcode, or other secrets.
+9. Write to `credentials/<app-id>.md` only when the user explicitly asks for local credential files.
+10. Read `core/memory/GUIDE.md` before reading or writing files under `memory/`.
 
 ## Non-Negotiables
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Skill-based runtimes can load `SKILL.md`; all runtimes should start with
 - the credentials guide under `core/credentials` only when a credential or human-gated screen appears.
 - `core/memory/GUIDE.md` only when reading or writing local agent-owned memory.
 - `apps/android/<package>/CARD.md` or `apps/ios/<bundle-id>/CARD.md` only for the foreground app.
+- `UPDATE.md` only when the session-start `git pull --ff-only` fails.
 
 
 ## Local Android Modes

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -1,0 +1,56 @@
+# mobile-harness update
+
+Use this file to keep an installed mobile-harness clone current. For
+first-time setup, read `install.md`.
+
+`<harness-root>` below is the directory containing this repository's
+`AGENTS.md`. When the harness is loaded through a CLAUDE.md import or a skill
+symlink, resolve the real repository path first.
+
+## Soft Update (default)
+
+Run once per session, before platform work:
+
+```bash
+git -C <harness-root> pull --ff-only
+```
+
+Handle the result:
+
+- Updated or already up to date: continue.
+- Offline or network failure: continue with the current version. Do not retry
+  in a loop and do not report it as an error.
+- `Not possible to fast-forward`, diverged history, or local-changes errors:
+  the clone needs repair. See Force Update.
+
+The soft update never overwrites local changes.
+
+## Force Update (repair)
+
+Force update resets the clone to the remote state and discards local
+modifications to tracked files:
+
+```bash
+git -C <harness-root> fetch origin
+git -C <harness-root> reset --hard origin/main
+```
+
+Rules:
+
+- Ask the user before running it. Tell them what the soft update refused
+  (dirty files, diverged history) and that local edits to tracked harness
+  files will be lost.
+- Never run `git clean -x`, `git clean -fdx`, or delete untracked files.
+  `memory/`, `credentials/`, and `.venv/` live inside this repository as
+  ignored directories. `reset --hard` leaves them alone; `git clean -x`
+  destroys them.
+- Do not repair a development checkout. If the user says the clone is where
+  they edit the harness itself, stop and let them resolve it.
+
+## After Updating
+
+- Files read earlier in this session may be stale. Re-read a guide before
+  relying on it.
+- If the update changed `AGENTS.md`, re-read it before continuing.
+- If `from mobilerun_core import Mobilerun` fails after an update, read
+  `install.md` and reinstall `mobilerun-core[local]` into `.venv/`.

--- a/install.md
+++ b/install.md
@@ -114,3 +114,9 @@ python -m pip install "mobilerun-core[local]"
 Provide the same environment variables listed above. If the host already
 provides `MOBILERUN_API_KEY`, set `MOBILERUN_CLOUD_API_KEY` to that value for
 `mobilerun-core`.
+
+## Updating
+
+Installed clones keep themselves current: `AGENTS.md` instructs agents to run
+`git pull --ff-only` against the repository once per session before platform
+work. Repair steps for clones the soft pull refuses are in `UPDATE.md`.


### PR DESCRIPTION
## What

Installed clones now keep themselves current via a pull-when-stale mechanism, with two modes:

- **Soft update (automatic):** new step 1 in the `AGENTS.md` load order — `git -C <harness-root> pull --ff-only` once per session before platform work. Offline → continue on the current version. Any other failure routes to `UPDATE.md`.
- **Force update (repair, consent-gated):** documented in the new root `UPDATE.md` — `fetch` + `reset --hard origin/main` for clones the soft pull refuses (dirty tree, diverged history). The agent must ask the user first.

`README.md` (Loading Model) and `install.md` get one-line pointers.

## Design notes

- The trigger lives in `AGENTS.md` because it is the universal entrypoint every runtime reads before platform work, making it runtime-agnostic (Claude Code, Codex, OpenClaw) with zero per-machine setup — no launchd jobs or hooks to install.
- `UPDATE.md` is a separate root file (sibling to `install.md`) following the harness's progressive-disclosure rule: agents load the repair detail only on failure.
- `UPDATE.md` explicitly forbids `git clean -x`/`-fdx`: `memory/`, `credentials/`, and `.venv/` live inside the clone as gitignored directories — `reset --hard` leaves them alone, `clean -x` would destroy user credentials, agent memory, and the Python install.
- Force update is barred on development checkouts; it repairs installed copies only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)