### PR TITLE
Document ADB-first local Android mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Read `install.md` and follow the steps to install `mobile-harness`.
 
 ## Scope
 
-- Android through `mobilerun-core` using local ADB+Portal, Portal HTTP-only, or cloud.
+- Android through `mobilerun-core` using local ADB with optional Portal, Portal HTTP-only, or cloud.
 - iOS through `mobilerun-core` using `ios-portal` HTTP or cloud.
 
 ## Manual Install
@@ -103,8 +103,8 @@ Skill-based runtimes can load `SKILL.md`; all runtimes should start with
 
 | ADB | Android Portal HTTP | Mode |
 | --- | --- | --- |
-| yes | yes | `backend="local-android-adb"`: core uses ADB+Portal; raw ADB is recovery. |
-| yes | no | `backend="local-android-adb"` may still work for ADB-native input/screenshot recovery only. |
+| yes | yes | `backend="local-android-adb"`: core uses ADB and automatically uses Portal features when available. |
+| yes | no | `backend="local-android-adb"`: core uses ADB-native control, UI, text input, screenshots, and app lifecycle. |
 | no | yes | `backend="local-android-http"` with the user-provided Portal base URL and bearer token. |
 | no | no | Blocked: ask the user to enable ADB or provide reachable Portal HTTP access. |
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -19,9 +19,9 @@ Normal device control always uses:
 from mobilerun_core import Mobilerun
 ```
 
-Use `Mobilerun()` to connect to cloud devices, local Android ADB+Portal, local
-Android Portal HTTP-only, or local iOS Portal HTTP. Do not import or call
-`mobilerun_core_cli` directly for normal agent work. `mobilerun-core-cli` is the
+Use `Mobilerun()` to connect to cloud devices, local Android ADB with optional
+Portal, local Android Portal HTTP-only, or local iOS Portal HTTP. Do not import
+or call `mobilerun_core_cli` directly for normal agent work. `mobilerun-core-cli` is the
 local-driver dependency used internally by `mobilerun-core` for Android and iOS
 local backends.
 

--- a/install.md
+++ b/install.md
@@ -30,7 +30,7 @@ Base `mobilerun-core` includes cloud support through `mobilerun-sdk`. The
 `local` extra installs `mobilerun-core-cli>=0.2.0`, which `mobilerun-core` uses
 internally for:
 
-- local Android ADB+Portal: `backend="local-android-adb"`
+- local Android ADB with optional Portal: `backend="local-android-adb"`
 - local Android Portal HTTP-only: `backend="local-android-http"`
 - local iOS Portal HTTP: `backend="local-ios-http"`
 

--- a/platforms/android/GUIDE.md
+++ b/platforms/android/GUIDE.md
@@ -1,6 +1,6 @@
 ---
 name: android-mobile-harness
-description: Use for Android phone control through mobilerun-core over cloud, ADB+Portal, or Portal HTTP-only. Classifies modes, defines observe-act-verify rules and app-card loading.
+description: Use for Android phone control through mobilerun-core over cloud, ADB with optional Portal, or Portal HTTP-only. Classifies modes, defines observe-act-verify rules and app-card loading.
 ---
 
 # Android Mobile Harness
@@ -15,7 +15,7 @@ Mobilerun Portal.
 - Cloud Android uses `backend="cloud"`.
 - Local public Portal only: `com.mobilerun.portal`.
 - Local Android backends require `mobilerun-core` installed with the `local` extra, or `mobilerun-core-cli` installed alongside it.
-- Raw ADB/curl is for setup checks, diagnostics, and recovery.
+- Direct raw ADB/curl is for setup checks, diagnostics, and recovery; normal control still goes through `mobilerun_core`.
 
 ## Primary Control
 
@@ -27,7 +27,7 @@ m = Mobilerun()
 # Cloud Android.
 device = m.connect("<cloud-device-id>", backend="cloud")
 
-# ADB + Portal local Android.
+# ADB-first local Android; Portal is used automatically when available.
 device = m.connect("<adb-serial>", backend="local-android-adb")
 
 # Portal HTTP-only local Android.
@@ -55,8 +55,8 @@ if device.supports("stop_app"):
 Classify before acting:
 
 1. **Cloud**: the user provided a Mobilerun Cloud device id. Use `backend="cloud"`.
-2. **Hybrid**: ADB works and Portal HTTP is reachable. Use `backend="local-android-adb"`.
-3. **ADB-only**: ADB works but Portal HTTP is unavailable. Use ADB only for recovery/setup; direct core control may have reduced sensing.
+2. **ADB + Portal**: ADB works and Portal is reachable. Use `backend="local-android-adb"`; core will use Portal-enhanced features automatically.
+3. **ADB-only**: ADB works but Portal is unavailable. Use `backend="local-android-adb"`; core still supports ADB-native UI, text input, screenshots, and app lifecycle.
 4. **Portal HTTP-only**: ADB is unavailable but the user provided a reachable Portal HTTP URL and bearer token. Use `backend="local-android-http"`.
 5. **Blocked**: no cloud device id, ADB, or reachable authenticated Portal HTTP is available. Stop and ask the user to provide a cloud device, enable ADB, or provide Portal HTTP access.
 
@@ -68,7 +68,7 @@ different endpoint.
 For cloud devices, do not run ADB checks, Android Portal HTTP probes, or local
 Portal recovery unless the user also provided a local Android target.
 
-If ADB works and `pm list packages com.mobilerun.portal` shows Portal installed, but `content://com.mobilerun.portal/version` fails or says provider not found, treat that as a Portal setup failure and read `platforms/android/recovery/GUIDE.md`; do not silently downgrade to generic ADB-only mode.
+If ADB works and `pm list packages com.mobilerun.portal` shows Portal installed, but `content://com.mobilerun.portal/version` fails or says provider not found, `mobilerun_core` can continue through ADB-first control. Treat the Portal issue as setup debt and read `platforms/android/recovery/GUIDE.md` only when Portal-specific features are required.
 
 An installed Portal app is not enough for Portal HTTP-only mode. The agent needs both:
 


### PR DESCRIPTION
## Summary
- Updates `local-android-adb` docs to describe ADB-first behavior with optional Portal enhancement.
- Clarifies that `local-android-http` is Portal HTTP-only and does not use ADB.
- Aligns mobile-harness guidance with the merged mobilerun-core and mobilerun-core-local behavior.

## Validation
- Documentation-only change.
- Related `mobilerun-core-local` validation: `uv run --with pytest python -m pytest tests/test_local_drivers.py` -> 22 passed; `uv run --with ruff ruff check mobilerun_core_local tests` -> All checks passed.
- Related `mobilerun-core` validation: `uv sync --extra local --locked --dry-run` selects `mobilerun-core-local==0.3.1`; `uv lock --check` clean; `uv run --with pytest python -m pytest tests -m "not cloud"` -> 126 passed, 42 deselected; `uv run --with ruff ruff check mobilerun_core tests` -> All checks passed.
- Full fresh-emulator regression passed on disposable API 36 AVD `mobilerun_adb_first_regression_api36`, serial `emulator-5556`, covering no-Portal ADB-only and Portal-present modes through both `mobilerun-core-local` and `mobilerun-core` wrapper paths.
- Local artifacts: `/private/tmp/mobilerun-adb-first-regression/20260623-201808/`.