### PR TITLE
Update mobile-harness local driver package naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Do not import local drivers directly for ordinary agent work.
 
 1. Update once per session, before platform work (`<harness-root>` is the directory containing this `AGENTS.md`):
    - `git -C <harness-root> pull --ff-only`
-   - `<harness-root>/.venv/bin/python -m pip install -U "mobilerun-core[local]" mobilerun-core-cli mobilerun-sdk`
+   - `<harness-root>/.venv/bin/python -m pip install -U "mobilerun-core[local]" mobilerun-core-local mobilerun-sdk`
    Skip the pip step if the libraries are pinned. If offline, continue with the current version. On any other failure, read `UPDATE.md`.
 2. Decide the target platform before acting.
 3. For Android work, read `platforms/android/GUIDE.md`.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Use /path/to/mobile-harness/.venv/bin/python for mobile-harness.
 ```
 
 Base `mobilerun-core` includes cloud support through `mobilerun-sdk`. The
-`local` extra installs `mobilerun-core-cli>=0.2.0`, which `mobilerun-core` uses
+`local` extra installs `mobilerun-core-local`, which `mobilerun-core` uses
 internally for local Android and iOS backends. Agents should still import only
 `mobilerun_core`.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -21,7 +21,7 @@ from mobilerun_core import Mobilerun
 
 Use `Mobilerun()` to connect to cloud devices, local Android ADB with optional
 Portal, local Android Portal HTTP-only, or local iOS Portal HTTP. Do not import
-or call `mobilerun_core_cli` directly for normal agent work. `mobilerun-core-cli` is the
+or call `mobilerun_core_local` directly for normal agent work. `mobilerun-core-local` is the
 local-driver dependency used internally by `mobilerun-core` for Android and iOS
 local backends.
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -53,7 +53,7 @@ The git pull only refreshes the Markdown harness; the control libraries in
 `.venv/` are versioned separately on PyPI. Upgrade them in the same pass:
 
 ```bash
-<harness-root>/.venv/bin/python -m pip install -U "mobilerun-core[local]" mobilerun-core-cli mobilerun-sdk
+<harness-root>/.venv/bin/python -m pip install -U "mobilerun-core[local]" mobilerun-core-local mobilerun-sdk
 <harness-root>/.venv/bin/python -c "from mobilerun_core import Mobilerun"
 ```
 

--- a/install.md
+++ b/install.md
@@ -16,7 +16,7 @@ python -m venv .venv
 ```
 
 Use Python 3.11, 3.12, or 3.13 to create the venv. `mobilerun-core` and
-`mobilerun-core-cli` currently require Python `>=3.11,<3.14`. If the default
+`mobilerun-core-local` currently require Python `>=3.11,<3.14`. If the default
 `python` is not compatible, use another compatible interpreter, but do not
 commit `.venv/`.
 
@@ -27,7 +27,7 @@ Use /path/to/mobile-harness/.venv/bin/python for mobile-harness.
 ```
 
 Base `mobilerun-core` includes cloud support through `mobilerun-sdk`. The
-`local` extra installs `mobilerun-core-cli>=0.2.0`, which `mobilerun-core` uses
+`local` extra installs `mobilerun-core-local`, which `mobilerun-core` uses
 internally for:
 
 - local Android ADB with optional Portal: `backend="local-android-adb"`
@@ -40,7 +40,7 @@ Agents should still import only `mobilerun_core`:
 from mobilerun_core import Mobilerun
 ```
 
-Do not teach agents to use `mobilerun_core_cli` directly for normal control.
+Do not teach agents to use `mobilerun_core_local` directly for normal control.
 
 ## Environment
 

--- a/platforms/android/GUIDE.md
+++ b/platforms/android/GUIDE.md
@@ -14,7 +14,7 @@ Mobilerun Portal.
 - Primary API is `mobilerun_core.Mobilerun`.
 - Cloud Android uses `backend="cloud"`.
 - Local public Portal only: `com.mobilerun.portal`.
-- Local Android backends require `mobilerun-core` installed with the `local` extra, or `mobilerun-core-cli` installed alongside it.
+- Local Android backends require `mobilerun-core` installed with the `local` extra, or `mobilerun-core-local` installed alongside it.
 - Direct raw ADB/curl is for setup checks, diagnostics, and recovery; normal control still goes through `mobilerun_core`.
 
 ## Primary Control

--- a/platforms/ios/GUIDE.md
+++ b/platforms/ios/GUIDE.md
@@ -14,7 +14,7 @@ Cloud or `ios-portal`.
 - Primary API is `mobilerun_core.Mobilerun`.
 - Cloud iOS uses `backend="cloud"`.
 - Local backend is `ios-portal` HTTP.
-- Local iOS requires `mobilerun-core` installed with the `local` extra, or `mobilerun-core-cli` installed alongside it.
+- Local iOS requires `mobilerun-core` installed with the `local` extra, or `mobilerun-core-local` installed alongside it.
 - No bearer token is required for local iOS Portal.
 
 ## Primary Control


### PR DESCRIPTION
## Summary

- Replaces stale `mobilerun-core-cli` references with `mobilerun-core-local`.
- Updates direct-module warning from `mobilerun_core_cli` to `mobilerun_core_local`.
- Leaves the existing ADB-first `local-android-adb` guidance intact.

## Notes

This is documentation-only. No runtime code changes are included.

## Verification

- `rg "mobilerun-core-cli|mobilerun_core_cli" /Users/rasulosmanbayli/Work/mobile-harness` returned no matches.
- Confirmed required docs exist: `AGENTS.md`, `SKILL.md`, `install.md`, `README.md`, `UPDATE.md`, `platforms/android/GUIDE.md`, `platforms/ios/GUIDE.md`.
- Confirmed there is no conventional test runner/test suite in this Markdown harness checkout.
- `git diff --check HEAD~1 HEAD` passed.