### PR TITLE
docs: sync guides with core 1.5.0 and core-local 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,17 +66,33 @@ device.start_app("com.android.settings")
 After connecting, agents should inspect `device.capabilities` and use
 `device.supports(...)` before optional operations.
 
+`device.execute_script("<js>")` runs JavaScript in the device's foreground
+Chrome tab and returns its JSON result. Cloud devices only; local backends
+raise `UnsupportedOperation`. Gate it with
+`device.supports("execute_script")`; the platform guides describe this key's
+network-probe behavior and its two server-side errors.
+
 ## Common Device Helpers
 
 Use these helpers through the `device` returned by `Mobilerun.connect(...)`:
 
 - `device.find_nodes(...)` searches the accessibility tree. `any_contains=`
   matches case-insensitive substrings across text, content description,
-  resource id, and accessibility identifier.
+  resource id, and accessibility identifier. Nodes may carry `offscreen: True`
+  (outside the viewport; scroll to reach it) and `hidden: True` (reported not
+  visible; scrolling alone may not reveal it). A missing flag is not proof of
+  visibility.
 - `device.tap_node(node)` taps the center of an accessibility node and raises
-  if the node has no usable bounds.
-- `device.tap_text("label")` finds and taps the first matching text,
-  description, resource id, or accessibility identifier.
+  if the node has no usable bounds. Before any bounds check, it raises a
+  distinct error for a node flagged hidden unless the node is also offscreen.
+- `device.tap_text("label")` taps the first on-screen, non-hidden match across
+  text, description, resource id, and accessibility identifier. It raises a
+  distinct error when matches exist but none are tappable on-screen.
+- `device.scroll(direction, distance=0.5, ms=..., verify=False)` scrolls
+  content-relative; `verify=True` returns whether the viewport actually moved.
+- `device.scroll_until(text_contains=..., direction="down", max_swipes=10)`
+  scrolls until a match is on-screen, returning the node or `None`. It stops
+  early with `None` when the viewport stops moving; do not re-call it blindly.
 - `device.type("text", clear=True)` clears the focused field before typing
   when the backend supports text input. `device.clear_input()` is available on
   local Android ADB and local iOS Portal HTTP.
@@ -142,6 +158,13 @@ Local iOS has one active capability mode:
 - `Blocked`: no reachable iOS Portal. Start `ios-portal` check info: https://github.com/droidrun/ios-portal
 
 The default local iOS Portal example is `http://127.0.0.1:6643`.
+
+A second local iOS server exists: `mobilerun-ios --local <udid>`, default
+`http://127.0.0.1:8080`, setup guide:
+https://docs.mobilerun.ai/guides/connect-iphone. `backend="local-ios-http"`
+speaks only the `ios-portal` contract and cannot connect to that server; do
+not point it at port 8080. `platforms/ios/GUIDE.md` explains how to tell the
+two apart.
 
 ## Local State
 

--- a/core/memory/GUIDE.md
+++ b/core/memory/GUIDE.md
@@ -28,7 +28,7 @@ Write memory near the end of a task when the fact is durable and useful:
 Use this shape:
 
 ```markdown
-- 2026-05-28: Fact. Source: observed via <Mobilerun Cloud|ADB|Android Portal HTTP|iOS Portal HTTP|user>. Confidence: high|medium|low.
+- 2026-05-28: Fact. Source: observed via <Mobilerun Cloud|ADB|Android Portal HTTP|iOS Portal app HTTP (6643)|iOS local portal HTTP (mobilerun-ios --local, 8080-8089)|user>. Confidence: high|medium|low.
 ```
 
 Update `memory/index.md` when creating a new memory file.

--- a/platforms/android/GUIDE.md
+++ b/platforms/android/GUIDE.md
@@ -50,6 +50,23 @@ if device.supports("stop_app"):
     device.stop_app("com.android.settings")
 ```
 
+`device.execute_script("<js>")` runs JavaScript in the device's foreground
+Chrome tab and returns its JSON result (`None` when the script returns
+`undefined`). Cloud devices only; local backends raise `UnsupportedOperation`.
+Gate it with `device.supports("execute_script")` and know its quirks:
+
+- On cloud connections this check fetches device capabilities over the
+  network, once per connection, and a fetch failure raises instead of
+  returning `False`. On local backends it returns `False` without any network
+  call.
+- It reports the device type, not the current Chrome state. A capable device
+  still fails with `DEVICE_NO_BROWSER_TARGET` when no debuggable foreground
+  Chrome tab exists; bring Chrome to the foreground and retry.
+- `DEVICE_TOOL_UNSUPPORTED` (HTTP 400) means the device type has no browser
+  tooling. Neither error is a connection failure.
+- `"execute_script"` appears in `device.capabilities["actions"]` only after a
+  successful `supports()` probe, so check via `supports()`, not the dict.
+
 ## Common Helpers
 
 Prefer accessibility-tree helpers over guessed coordinates:
@@ -57,11 +74,32 @@ Prefer accessibility-tree helpers over guessed coordinates:
 - `device.find_nodes(...)` accepts filters such as `text=`, `desc=`,
   `resource_id=`, `text_contains=`, `desc_contains=`, and `any_contains=`.
   `any_contains=` matches case-insensitive substrings across text, content
-  description, resource id, and accessibility identifier.
+  description, resource id, and accessibility identifier. Nodes may carry two
+  flags: `offscreen: True` marks a real element outside the viewport, scroll
+  to reach it; `hidden: True` marks an element Android reports as not visible,
+  collapsed or covered, so scrolling alone may not reveal it unless it is also
+  offscreen. A missing flag is not proof of visibility; older tree sources do
+  not emit `hidden`.
 - `device.tap_node(node)` taps the center of a node and fails clearly if bounds
-  are missing or unusable.
-- `device.tap_text("label")` finds and taps the first matching text,
-  description, resource id, or accessibility identifier.
+  are missing or unusable. Before any bounds check, it raises a distinct error
+  for a node flagged hidden unless the node is also offscreen; change the UI
+  state instead of retrying that tap. For an offscreen node, bring it into
+  view with `scroll_until` first.
+- `device.tap_text("label")` taps the first on-screen, non-hidden match across
+  text, description, resource id, and accessibility identifier. It raises a
+  distinct error when matches exist but none are tappable on-screen; the
+  message says whether to scroll or to re-inspect.
+- `device.scroll(direction, distance=0.5, ms=..., verify=False)` scrolls
+  content-relative: `"down"` reveals rows below. `distance` is a fraction of
+  half the screen. `verify=True` returns whether the viewport actually moved,
+  at the cost of two extra UI reads; otherwise the call returns `None`. Raise
+  `ms=` for lists that swallow fast swipes.
+- `device.scroll_until(text_contains=..., direction="down", max_swipes=10)`
+  scrolls until a match is on-screen and not hidden, returning the node or
+  `None`. On a viewport stall it retries once with a stronger swipe, then
+  returns `None` early. Early `None` means the viewport stopped moving; `None`
+  after `max_swipes` means the swipe budget ran out. Do not re-call it
+  blindly.
 - `device.type("text", clear=True)` clears the focused field before typing.
   ADB-only mode supports ordinary text input; Portal remains the richer path
   when available.
@@ -124,6 +162,13 @@ Then use `http://127.0.0.1:18080` as the Portal URL.
 Default device port is `8080`.
 
 - `GET /ping` does not require auth and should return `pong`.
+- `/ping` alone does not prove the target is an Android Portal: the local iOS
+  portal (`mobilerun-ios --local`) answers the same `pong` and also defaults
+  to port 8080. When the platform is ambiguous, probe `GET /version`: a 200
+  whose JSON `result` field starts with `iosportal(` is the iOS local portal
+  (it answers without auth unless started with `--local-token`). A 401/403 is
+  ambiguous: either an Android Portal without a valid bearer token or a
+  token-protected iOS local portal. Ask the user which server owns the port.
 - Every other endpoint requires `Authorization: Bearer <token>`.
 - Verify the token with `GET /version` before connecting through `mobilerun-core`.
 

--- a/platforms/ios/GUIDE.md
+++ b/platforms/ios/GUIDE.md
@@ -13,9 +13,11 @@ Cloud or `ios-portal`.
 - iOS only.
 - Primary API is `mobilerun_core.Mobilerun`.
 - Cloud iOS uses `backend="cloud"`.
-- Local backend is `ios-portal` HTTP.
+- The local backend `local-ios-http` speaks the `ios-portal` Portal app
+  contract only. It cannot drive the `mobilerun-ios --local` server; see
+  "Two Local iOS Portals" below.
 - Local iOS requires `mobilerun-core` installed with the `local` extra, or `mobilerun-core-local` installed alongside it.
-- No bearer token is required for local iOS Portal.
+- No bearer token is required for the local iOS Portal app.
 
 ## Primary Control
 
@@ -41,20 +43,85 @@ Use `MOBILERUN_IOS_PORTAL_URL` to omit `url=`.
 After connecting, inspect `device.capabilities` and use `device.supports(...)`
 before optional operations.
 
+`device.execute_script("<js>")` runs JavaScript in the device's foreground
+Chrome tab and returns its JSON result (`None` when the script returns
+`undefined`). Cloud devices only; local backends raise `UnsupportedOperation`.
+Gate it with `device.supports("execute_script")`. On cloud connections this
+check fetches device capabilities over the network once per connection, a
+fetch failure raises instead of returning `False`, and it reports the device
+type rather than the current browser state. On local backends it returns
+`False` without any network call. `DEVICE_NO_BROWSER_TARGET` means
+no debuggable foreground Chrome tab right now; `DEVICE_TOOL_UNSUPPORTED`
+(HTTP 400) means the device type has no browser tooling. Neither error is a
+connection failure.
+
 ## Common Helpers
 
 Use the `device` returned by `Mobilerun.connect(...)`:
 
 - `device.find_nodes(...)` searches the accessibility tree. `any_contains=`
   matches case-insensitive substrings across text, content description,
-  resource id, and accessibility identifier.
+  resource id, and accessibility identifier. Nodes may carry `offscreen: True`
+  or `hidden: True` when the tree source reports visibility. A missing flag is
+  not proof of visibility; iOS Portal tree sources may not emit them.
 - `device.tap_node(node)` taps the center of a node and fails clearly if bounds
-  are missing or unusable.
-- `device.tap_text("label")` finds and taps the first matching text,
-  description, resource id, or accessibility identifier.
+  are missing or unusable. It may also reject a node flagged hidden.
+- `device.tap_text("label")` taps the first on-screen match across text,
+  description, resource id, and accessibility identifier. It raises a distinct
+  error when matches exist but none are tappable on-screen.
+- `device.scroll(direction, distance=0.5, ms=..., verify=False)` scrolls
+  content-relative: `"down"` reveals rows below. `distance` is a fraction of
+  half the screen. `verify=True` returns whether the viewport actually moved,
+  at the cost of two extra UI reads; otherwise the call returns `None`.
+- `device.scroll_until(text_contains=..., direction="down", max_swipes=10)`
+  scrolls until a match is on-screen, returning the node or `None`. On a
+  viewport stall it retries once with a stronger swipe, then returns `None`
+  early instead of using the whole swipe budget. Do not re-call it blindly.
 - `device.type("text", clear=True)` clears the focused field before typing
   when text input is supported.
 - `device.clear_input()` is supported by local iOS Portal HTTP.
+
+## Two Local iOS Portals
+
+Two local iOS servers exist and speak incompatible HTTP contracts:
+
+- **iOS Portal app** (`ios-portal`): default `http://127.0.0.1:6643`, one
+  port per device (probe 6643-6652), no token. Contract: `GET /device/date`,
+  `GET /state`, `GET /vision/screenshot`. This is the only contract
+  `backend="local-ios-http"` can drive.
+- **`mobilerun-ios --local <udid>`**: a host-side server, default
+  `http://127.0.0.1:8080`, one port per attached device (probe 8080-8089). It
+  speaks the Android-Portal-style contract (`/ping`, `/version`,
+  `/state_full`, `/screenshot`) and serves none of the Portal app endpoints.
+  Tokenless unless started with `--local-token` (mandatory for non-loopback
+  binds); then `Authorization: Bearer <--local-token value>`. Setup guide:
+  https://docs.mobilerun.ai/guides/connect-iphone
+
+To tell them apart, probe both port ranges:
+
+```bash
+for p in $(seq 8080 8089); do curl -sS "http://127.0.0.1:$p/version" && echo " <- $p"; done
+for p in $(seq 6643 6652); do curl -sS "http://127.0.0.1:$p/device/date" && echo " <- $p"; done
+```
+
+Interpret the responses:
+
+- A 200 body like `{"status":"success","result":"iosportal(..."}` on
+  `/version` identifies the `mobilerun-ios --local` server. Only the
+  `iosportal(` prefix inside the JSON `result` field is decisive.
+- A 200 JSON body with a `date` field on `/device/date` identifies the Portal
+  app.
+- A 401/403 on `/version` is ambiguous: either a `mobilerun-ios --local`
+  server started with `--local-token`, or a forwarded Android Portal without a
+  bearer token. Ask the user which server owns the port.
+- A `pong` from `/ping` is ambiguous; the Android Portal answers the same.
+- Anything else (404, HTML, connection refused) means an unrelated server or
+  no server.
+
+If only the `mobilerun-ios --local` server is running, do not point
+`backend="local-ios-http"` at it and do not start a second portal next to it.
+Report that `mobilerun_core` cannot drive it and ask the user whether to start
+the Portal app instead.
 
 ## Capability Classification
 
@@ -62,7 +129,7 @@ Classify before acting:
 
 1. **Cloud**: the user provided a Mobilerun Cloud device id. Use `backend="cloud"`.
 2. **iOS Portal HTTP**: `MOBILERUN_IOS_PORTAL_URL` is reachable and `GET /device/date`, `GET /state`, and `GET /vision/screenshot` work.
-3. **Blocked**: no cloud device id or reachable iOS Portal is available. Stop and ask the user to provide a cloud device or start `ios-portal`.
+3. **Blocked**: no cloud device id or reachable iOS Portal is available. Run the port probe in "Two Local iOS Portals" before concluding this; a running `mobilerun-ios --local` server is not "no portal". Then stop and ask the user to provide a cloud device or start `ios-portal`.
 
 Cloud requires `MOBILERUN_CLOUD_API_KEY`, `MOBILERUN_API_BASE_URL`, and
 `MOBILERUN_CLOUD_DEVICE_ID`. Use

--- a/platforms/ios/GUIDE.md
+++ b/platforms/ios/GUIDE.md
@@ -113,7 +113,9 @@ Interpret the responses:
   `/version` identifies the `mobilerun-ios --local` server. Only the
   `iosportal(` prefix inside the JSON `result` field is decisive.
 - A 200 JSON body with a `date` field on `/device/date` identifies the Portal
-  app.
+  app. If it serves the target device, connect there:
+  `backend="local-ios-http"` with that base URL (set
+  `MOBILERUN_IOS_PORTAL_URL` or pass `url=`).
 - A 401/403 on `/version` counts as a portal only if the same port answers
   `GET /ping` with the unauthenticated `pong` envelope; both portals exempt
   `/ping` from auth. With the `pong` it is either a `mobilerun-ios --local`

--- a/platforms/ios/GUIDE.md
+++ b/platforms/ios/GUIDE.md
@@ -100,8 +100,8 @@ Two local iOS servers exist and speak incompatible HTTP contracts:
 To tell them apart, probe both port ranges:
 
 ```bash
-for p in $(seq 8080 8089); do curl -sS -w " [%{http_code}] <- $p\n" "http://127.0.0.1:$p/version"; done
-for p in $(seq 6643 6652); do curl -sS -w " [%{http_code}] <- $p\n" "http://127.0.0.1:$p/device/date"; done
+for p in $(seq 8080 8089); do curl -sS --max-time 3 -w " [%{http_code}] <- $p\n" "http://127.0.0.1:$p/version"; done
+for p in $(seq 6643 6652); do curl -sS --max-time 3 -w " [%{http_code}] <- $p\n" "http://127.0.0.1:$p/device/date"; done
 ```
 
 Each line prints the response body followed by the HTTP status; `[000]` means

--- a/platforms/ios/GUIDE.md
+++ b/platforms/ios/GUIDE.md
@@ -121,10 +121,17 @@ Interpret the responses:
 - Anything else (404, HTML, connection refused) means an unrelated server or
   no server.
 
-If only the `mobilerun-ios --local` server is running, do not point
+`/version` does not say which device a server serves. On a host with several
+attached devices, correlate first: `pgrep -af mobilerun-ios` shows the UDIDs
+the server was started with (none when it auto-discovered devices), and its
+startup log prints the device behind each URL. If ownership stays unclear,
+ask the user.
+
+If the `mobilerun-ios --local` server serves the target device, do not point
 `backend="local-ios-http"` at it and do not start a second portal next to it.
 Report that `mobilerun_core` cannot drive it and ask the user whether to start
-the Portal app instead.
+the Portal app instead. A server that serves only other devices does not
+block Portal app setup for the target device.
 
 ## Capability Classification
 

--- a/platforms/ios/GUIDE.md
+++ b/platforms/ios/GUIDE.md
@@ -124,11 +124,13 @@ Interpret the responses:
 - Anything else (404, HTML, connection refused) means an unrelated server or
   no server.
 
-`/version` does not say which device a server serves. On a host with several
-attached devices, correlate first: `pgrep -af mobilerun-ios` shows the UDIDs
-the server was started with (none when it auto-discovered devices), and its
-startup log prints the device behind each URL. If ownership stays unclear,
-ask the user.
+Neither `/version` nor `/device/date` says which device a server serves. On a
+host with several attached devices, correlate first: `pgrep -af
+mobilerun-ios` shows the UDIDs a `--local` server was started with (none when
+it auto-discovered devices), and its startup log prints the device behind
+each URL; `pgrep -af iproxy` shows the UDID behind each forwarded Portal app
+port; `pgrep -af xcodebuild` shows a Portal app's simulator name or device id
+in its `-destination` argument. If ownership stays unclear, ask the user.
 
 If the `mobilerun-ios --local` server serves the target device, do not point
 `backend="local-ios-http"` at it and do not start a second portal next to it.

--- a/platforms/ios/GUIDE.md
+++ b/platforms/ios/GUIDE.md
@@ -114,9 +114,12 @@ Interpret the responses:
   `iosportal(` prefix inside the JSON `result` field is decisive.
 - A 200 JSON body with a `date` field on `/device/date` identifies the Portal
   app.
-- A 401/403 on `/version` is ambiguous: either a `mobilerun-ios --local`
-  server started with `--local-token`, or a forwarded Android Portal without a
-  bearer token. Ask the user which server owns the port.
+- A 401/403 on `/version` counts as a portal only if the same port answers
+  `GET /ping` with the unauthenticated `pong` envelope; both portals exempt
+  `/ping` from auth. With the `pong` it is either a `mobilerun-ios --local`
+  server started with `--local-token` or a forwarded Android Portal without a
+  bearer token; ask the user which server owns the port. Without the `pong`
+  it is an unrelated authenticated service.
 - A `pong` from `/ping` is ambiguous; the Android Portal answers the same.
 - Anything else (404, HTML, connection refused) means an unrelated server or
   no server.

--- a/platforms/ios/GUIDE.md
+++ b/platforms/ios/GUIDE.md
@@ -125,12 +125,17 @@ Interpret the responses:
   no server.
 
 Neither `/version` nor `/device/date` says which device a server serves. On a
-host with several attached devices, correlate first: `pgrep -af
-mobilerun-ios` shows the UDIDs a `--local` server was started with (none when
-it auto-discovered devices), and its startup log prints the device behind
-each URL; `pgrep -af iproxy` shows the UDID behind each forwarded Portal app
-port; `pgrep -af xcodebuild` shows a Portal app's simulator name or device id
-in its `-destination` argument. If ownership stays unclear, ask the user.
+host with several attached devices, correlate first:
+
+```bash
+ps ax -o pid,command | grep -E "mobilerun-ios|iproxy|xcodebuild" | grep -v grep
+```
+
+A `--local` server's arguments show the UDIDs it was started with (none when
+it auto-discovered devices; its startup log prints the device behind each
+URL). An `iproxy` process shows the UDID behind each forwarded Portal app
+port. A Portal app's `xcodebuild` process shows the simulator name or device
+id in its `-destination` argument. If ownership stays unclear, ask the user.
 
 If the `mobilerun-ios --local` server serves the target device, do not point
 `backend="local-ios-http"` at it and do not start a second portal next to it.

--- a/platforms/ios/GUIDE.md
+++ b/platforms/ios/GUIDE.md
@@ -100,9 +100,12 @@ Two local iOS servers exist and speak incompatible HTTP contracts:
 To tell them apart, probe both port ranges:
 
 ```bash
-for p in $(seq 8080 8089); do curl -sS "http://127.0.0.1:$p/version" && echo " <- $p"; done
-for p in $(seq 6643 6652); do curl -sS "http://127.0.0.1:$p/device/date" && echo " <- $p"; done
+for p in $(seq 8080 8089); do curl -sS -w " [%{http_code}] <- $p\n" "http://127.0.0.1:$p/version"; done
+for p in $(seq 6643 6652); do curl -sS -w " [%{http_code}] <- $p\n" "http://127.0.0.1:$p/device/date"; done
 ```
+
+Each line prints the response body followed by the HTTP status; `[000]` means
+no HTTP response at all.
 
 Interpret the responses:
 

--- a/platforms/ios/recovery/GUIDE.md
+++ b/platforms/ios/recovery/GUIDE.md
@@ -25,8 +25,8 @@ starting at 8080 and serves none of `/device/date`, `/state`, or
 the rules in "Two Local iOS Portals" in `platforms/ios/GUIDE.md`:
 
 ```bash
-for p in $(seq 8080 8089); do curl -sS -w " [%{http_code}] <- $p\n" "http://127.0.0.1:$p/version"; done
-for p in $(seq 6643 6652); do curl -sS -w " [%{http_code}] <- $p\n" "http://127.0.0.1:$p/device/date"; done
+for p in $(seq 8080 8089); do curl -sS --max-time 3 -w " [%{http_code}] <- $p\n" "http://127.0.0.1:$p/version"; done
+for p in $(seq 6643 6652); do curl -sS --max-time 3 -w " [%{http_code}] <- $p\n" "http://127.0.0.1:$p/device/date"; done
 ```
 
 Each line prints the response body followed by the HTTP status; `[000]` means

--- a/platforms/ios/recovery/GUIDE.md
+++ b/platforms/ios/recovery/GUIDE.md
@@ -35,12 +35,13 @@ no HTTP response at all.
 If a `/version` body's `result` field starts with `iosportal(`, a
 `mobilerun-ios --local` server is running; `backend="local-ios-http"` cannot
 connect to it. Neither `/version` nor `/device/date` says which device a
-server serves. On a multi-device host, correlate every hit with the target:
-`pgrep -af mobilerun-ios` shows the UDIDs a `--local` server was started with,
-and its startup log prints the device behind each URL; `pgrep -af iproxy`
-shows the UDID behind each forwarded Portal app port; `pgrep -af xcodebuild`
-shows a Portal app's simulator name or device id in its `-destination`
-argument. When a `--local` server serves the target device, do not start a
+server serves. On a multi-device host, correlate every hit with the target
+via `ps ax -o pid,command | grep -E "mobilerun-ios|iproxy|xcodebuild"`: a
+`--local` server's arguments show the UDIDs it was started with, and its
+startup log prints the device behind each URL; an `iproxy` process shows the
+UDID behind each forwarded Portal app port; an `xcodebuild` process shows a
+Portal app's simulator name or device id in its `-destination` argument.
+When a `--local` server serves the target device, do not start a
 second portal next to it; report the mismatch and ask the user whether to
 switch to the Portal app. When ownership stays unclear, ask the user. A 401/403 counts as a
 portal only if the same port that returned it answers

--- a/platforms/ios/recovery/GUIDE.md
+++ b/platforms/ios/recovery/GUIDE.md
@@ -9,12 +9,37 @@ Use this only after a concrete iOS control failure.
 
 ## Classify The Failure
 
-- **No iOS Portal**: `MOBILERUN_IOS_PORTAL_URL` is missing or `/device/date` cannot be reached.
+- **No iOS Portal**: `MOBILERUN_IOS_PORTAL_URL` is missing or `/device/date` cannot be reached. Run Portal Triage before Setup Recovery.
 - **Portal server exited**: requests start failing after earlier success, usually because the XCTest runner stopped.
 - **State extraction failure**: `/state` returns HTTP 200 but required state fields are missing or repeatedly empty while the UI is stable.
 - **Screenshot failure**: `/vision/screenshot` is non-PNG, zero bytes, or times out.
 - **Input failed**: tap/type returns success but the UI did not change.
 - **App blocked**: Crash or frozen UI.
+
+## Portal Triage
+
+A failed `/device/date` probe does not prove that no portal is running. The
+`mobilerun-ios --local <udid>` server takes one port per attached device
+starting at 8080 and serves none of `/device/date`, `/state`, or
+`/vision/screenshot`. Probe both port ranges and interpret the responses by
+the rules in "Two Local iOS Portals" in `platforms/ios/GUIDE.md`:
+
+```bash
+for p in $(seq 8080 8089); do curl -sS "http://127.0.0.1:$p/version" && echo " <- $p"; done
+for p in $(seq 6643 6652); do curl -sS "http://127.0.0.1:$p/device/date" && echo " <- $p"; done
+```
+
+If a `/version` body's `result` field starts with `iosportal(`, a
+`mobilerun-ios --local` server is running; `backend="local-ios-http"` cannot
+connect to it. Do not start a second portal next to it. Report the mismatch
+and ask the user whether to switch to the Portal app. A 401/403 is ambiguous
+(token-protected `mobilerun-ios --local` or a forwarded Android Portal); ask
+the user which server owns the port.
+
+Continue with Setup Recovery only when no port returned a portal-shaped
+response: no `iosportal(` `/version` result, no 401/403, and no `/device/date`
+body with a `date` field. Unrelated HTTP answers (404, HTML) do not block
+Setup Recovery.
 
 ## Setup Recovery
 

--- a/platforms/ios/recovery/GUIDE.md
+++ b/platforms/ios/recovery/GUIDE.md
@@ -34,12 +34,15 @@ no HTTP response at all.
 
 If a `/version` body's `result` field starts with `iosportal(`, a
 `mobilerun-ios --local` server is running; `backend="local-ios-http"` cannot
-connect to it. `/version` does not say which device it serves. On a
-multi-device host, correlate first: `pgrep -af mobilerun-ios` shows the UDIDs
-the server was started with, and its startup log prints the device behind
-each URL. When it serves the target device, do not start a second portal next
-to it; report the mismatch and ask the user whether to switch to the Portal
-app. When ownership stays unclear, ask the user. A 401/403 counts as a
+connect to it. Neither `/version` nor `/device/date` says which device a
+server serves. On a multi-device host, correlate every hit with the target:
+`pgrep -af mobilerun-ios` shows the UDIDs a `--local` server was started with,
+and its startup log prints the device behind each URL; `pgrep -af iproxy`
+shows the UDID behind each forwarded Portal app port; `pgrep -af xcodebuild`
+shows a Portal app's simulator name or device id in its `-destination`
+argument. When a `--local` server serves the target device, do not start a
+second portal next to it; report the mismatch and ask the user whether to
+switch to the Portal app. When ownership stays unclear, ask the user. A 401/403 counts as a
 portal only if the same port that returned it answers
 `curl -sS --max-time 3 "http://127.0.0.1:<port>/ping"` with the
 unauthenticated `pong` envelope; both portals exempt `/ping` from auth. With the `pong` it is
@@ -50,9 +53,10 @@ authenticated service.
 Continue with Setup Recovery when no port returned a portal-shaped response
 (no `iosportal(` `/version` result, no 401/403 corroborated by a `/ping`
 `pong`, and no `/device/date` body with a `date` field), or when every
-`iosportal(` hit serves a device other than the target. Unrelated HTTP
-answers (404, HTML, or 401/403 without the `pong`) do not block Setup
-Recovery.
+portal-shaped hit serves a device other than the target. Another device's
+healthy portal never blocks recovery of the target, but its port stays taken;
+follow the port-in-use rule in Setup Recovery. Unrelated HTTP answers (404,
+HTML, or 401/403 without the `pong`) do not block Setup Recovery.
 
 ## Setup Recovery
 
@@ -73,7 +77,7 @@ iproxy -u <device-udid> -s 127.0.0.1 6643:6643
 curl -fsS http://127.0.0.1:6643/device/date
 ```
 
-If the port is already in use, stop the prior portal process or ask the user for a clean port/device setup. Do not guess a different device.
+If the port is already in use by another device's healthy portal, ask the user for a clean port setup; do not stop that portal. If it is held by a stale process for the target device, stop that process. Do not guess a different device.
 
 ## Action Recovery
 

--- a/platforms/ios/recovery/GUIDE.md
+++ b/platforms/ios/recovery/GUIDE.md
@@ -40,9 +40,9 @@ the server was started with, and its startup log prints the device behind
 each URL. When it serves the target device, do not start a second portal next
 to it; report the mismatch and ask the user whether to switch to the Portal
 app. When ownership stays unclear, ask the user. A 401/403 counts as a
-portal only if the same port answers
-`curl -sS --max-time 3 "http://127.0.0.1:$p/ping"` with the unauthenticated
-`pong` envelope; both portals exempt `/ping` from auth. With the `pong` it is
+portal only if the same port that returned it answers
+`curl -sS --max-time 3 "http://127.0.0.1:<port>/ping"` with the
+unauthenticated `pong` envelope; both portals exempt `/ping` from auth. With the `pong` it is
 a token-protected `mobilerun-ios --local` or a forwarded Android Portal; ask
 the user which server owns the port. Without the `pong` it is an unrelated
 authenticated service.

--- a/platforms/ios/recovery/GUIDE.md
+++ b/platforms/ios/recovery/GUIDE.md
@@ -51,6 +51,12 @@ a token-protected `mobilerun-ios --local` or a forwarded Android Portal; ask
 the user which server owns the port. Without the `pong` it is an unrelated
 authenticated service.
 
+A `/device/date` hit that serves the target device means its Portal app is
+already running on that port; do not run Setup Recovery. Verify the port with
+the probes in "iOS Portal HTTP Contract" in `platforms/ios/GUIDE.md`, then
+reconnect through `Mobilerun` with `backend="local-ios-http"` and that base
+URL (set `MOBILERUN_IOS_PORTAL_URL` or pass `url=`).
+
 Continue with Setup Recovery when no port returned a portal-shaped response
 (no `iosportal(` `/version` result, no 401/403 corroborated by a `/ping`
 `pong`, and no `/device/date` body with a `date` field), or when every

--- a/platforms/ios/recovery/GUIDE.md
+++ b/platforms/ios/recovery/GUIDE.md
@@ -25,9 +25,12 @@ starting at 8080 and serves none of `/device/date`, `/state`, or
 the rules in "Two Local iOS Portals" in `platforms/ios/GUIDE.md`:
 
 ```bash
-for p in $(seq 8080 8089); do curl -sS "http://127.0.0.1:$p/version" && echo " <- $p"; done
-for p in $(seq 6643 6652); do curl -sS "http://127.0.0.1:$p/device/date" && echo " <- $p"; done
+for p in $(seq 8080 8089); do curl -sS -w " [%{http_code}] <- $p\n" "http://127.0.0.1:$p/version"; done
+for p in $(seq 6643 6652); do curl -sS -w " [%{http_code}] <- $p\n" "http://127.0.0.1:$p/device/date"; done
 ```
+
+Each line prints the response body followed by the HTTP status; `[000]` means
+no HTTP response at all.
 
 If a `/version` body's `result` field starts with `iosportal(`, a
 `mobilerun-ios --local` server is running; `backend="local-ios-http"` cannot

--- a/platforms/ios/recovery/GUIDE.md
+++ b/platforms/ios/recovery/GUIDE.md
@@ -34,15 +34,20 @@ no HTTP response at all.
 
 If a `/version` body's `result` field starts with `iosportal(`, a
 `mobilerun-ios --local` server is running; `backend="local-ios-http"` cannot
-connect to it. Do not start a second portal next to it. Report the mismatch
-and ask the user whether to switch to the Portal app. A 401/403 is ambiguous
+connect to it. `/version` does not say which device it serves. On a
+multi-device host, correlate first: `pgrep -af mobilerun-ios` shows the UDIDs
+the server was started with, and its startup log prints the device behind
+each URL. When it serves the target device, do not start a second portal next
+to it; report the mismatch and ask the user whether to switch to the Portal
+app. When ownership stays unclear, ask the user. A 401/403 is ambiguous
 (token-protected `mobilerun-ios --local` or a forwarded Android Portal); ask
 the user which server owns the port.
 
-Continue with Setup Recovery only when no port returned a portal-shaped
-response: no `iosportal(` `/version` result, no 401/403, and no `/device/date`
-body with a `date` field. Unrelated HTTP answers (404, HTML) do not block
-Setup Recovery.
+Continue with Setup Recovery when no port returned a portal-shaped response
+(no `iosportal(` `/version` result, no 401/403, and no `/device/date` body
+with a `date` field), or when every `iosportal(` hit serves a device other
+than the target. Unrelated HTTP answers (404, HTML) do not block Setup
+Recovery.
 
 ## Setup Recovery
 

--- a/platforms/ios/recovery/GUIDE.md
+++ b/platforms/ios/recovery/GUIDE.md
@@ -39,14 +39,19 @@ multi-device host, correlate first: `pgrep -af mobilerun-ios` shows the UDIDs
 the server was started with, and its startup log prints the device behind
 each URL. When it serves the target device, do not start a second portal next
 to it; report the mismatch and ask the user whether to switch to the Portal
-app. When ownership stays unclear, ask the user. A 401/403 is ambiguous
-(token-protected `mobilerun-ios --local` or a forwarded Android Portal); ask
-the user which server owns the port.
+app. When ownership stays unclear, ask the user. A 401/403 counts as a
+portal only if the same port answers
+`curl -sS --max-time 3 "http://127.0.0.1:$p/ping"` with the unauthenticated
+`pong` envelope; both portals exempt `/ping` from auth. With the `pong` it is
+a token-protected `mobilerun-ios --local` or a forwarded Android Portal; ask
+the user which server owns the port. Without the `pong` it is an unrelated
+authenticated service.
 
 Continue with Setup Recovery when no port returned a portal-shaped response
-(no `iosportal(` `/version` result, no 401/403, and no `/device/date` body
-with a `date` field), or when every `iosportal(` hit serves a device other
-than the target. Unrelated HTTP answers (404, HTML) do not block Setup
+(no `iosportal(` `/version` result, no 401/403 corroborated by a `/ping`
+`pong`, and no `/device/date` body with a `date` field), or when every
+`iosportal(` hit serves a device other than the target. Unrelated HTTP
+answers (404, HTML, or 401/403 without the `pong`) do not block Setup
 Recovery.
 
 ## Setup Recovery


### PR DESCRIPTION
## Summary

Updates the harness docs to match installed `mobilerun-core` 1.5.0 and `mobilerun-core-local` 0.6.0. Doc-only; the runtime path (`import only mobilerun_core`) needed no changes.

- **Two local iOS portals** (`platforms/ios/GUIDE.md`): document the host-side `mobilerun-ios --local` server (port 8080, one per device) next to the Portal app (6643), with the `/version` probe that tells the contracts apart. `backend="local-ios-http"` drives the Portal app contract only and cannot connect to the `--local` server.
- **iOS recovery triage** (`platforms/ios/recovery/GUIDE.md`): probe both port ranges before treating the portal as absent, so a running `--local` server is reported instead of a second portal being started next to it. Only portal-shaped responses block Setup Recovery.
- **Node visibility flags** (both platform guides, README): `offscreen`/`hidden` flags in `find_nodes` output, the distinct `tap_node`/`tap_text` errors they produce, and that a missing flag is not proof of visibility.
- **Scrolling** (both platform guides, README): `scroll(direction, distance, ms=, verify=)` semantics and `scroll_until` stall detection (early `None` means the viewport stopped moving).
- **`device.execute_script`** (both platform guides, README): cloud-only Chrome JS injection, the network-fetching `supports("execute_script")` gate, and the two server-side errors.
- **`/ping` ambiguity** (`platforms/android/GUIDE.md`): the iOS local portal answers the same `pong` on the same default port; `/version` disambiguates, and 401/403 stays ambiguous.
- **Memory source labels** (`core/memory/GUIDE.md`): split the iOS surface into Portal app HTTP (6643) and iOS local portal HTTP (8080-8089).

## Verification

- All method signatures, defaults, flag names, error conditions, ports, and endpoint shapes checked against the installed packages in `.venv` (mobilerun-core 1.5.0, mobilerun-core-local 0.6.0).
- Cross-file consistency checked: the probe commands and response interpretations match across the iOS guide, iOS recovery, and Android guide.
- Markdown fences balanced; no em dashes.

DRO-2603

🤖 Generated with [Claude Code](https://claude.com/claude-code)