### PR TITLE
DO NOT MERGE: verify CI gate fails correctly

### DIFF
--- a/core/mobile-ux-primitives/gestures.md
+++ b/core/mobile-ux-primitives/gestures.md
@@ -26,3 +26,9 @@ Long-press-then-drag reorders list items, moves home-screen icons, or moves card
 
 ## Scroll vs. swipe ambiguity
 A vertical drag on a feed scrolls; a vertical drag on a horizontally-paged carousel (stories, image galleries within a post) may do nothing or bleed into the parent scroll. When an app has both nested horizontal and outer vertical scrolling regions, a failed gesture is often a hit-target problem, not a wrong-gesture problem — try anchoring the gesture more precisely inside the intended region.
+
+<!-- BEGIN curator-candidate: review and fold into the prose above, or delete -->
+## Curator-suggested additions (unreviewed)
+
+- `deliberately-leaked-block` — temporary, to verify CI catches this
+<!-- END curator-candidate -->


### PR DESCRIPTION
Throwaway PR, will be closed without merging.

Verifies two behaviours in `.github/workflows/tests.yml` that were asserted but never observed:

1. `gate` reports **failure** when the test matrix fails (it must, since it's the check branch protection will require).
2. `!cancelled()` step gating lets `Curator` and the clean-tree step run after `Repo structure` fails, so one run reports every regression.

Method: commit a curator-candidate block into `core/mobile-ux-primitives/gestures.md`, which `test_no_unreviewed_curator_draft_is_committed_under_core` exists to catch. This also confirms that guard works end to end in CI rather than only locally.

Expected: `Repo structure` fails, `Curator` and the clean-tree step still run and pass, `test (3.9)`/`test (3.13)` fail, `gate` fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)