### PR TITLE
docs: sharpen skill trigger description and add skills-cli update fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Do not import local drivers directly for ordinary agent work.
    The explicit `mobilerun-core-local` and `mobilerun-sdk` entries keep those
    runtime packages upgraded even when they are already satisfied transitive
    dependencies. Agents should still import only `mobilerun_core`.
-   Skip the pip step if the libraries are pinned. If `<harness-root>` is not a git checkout (for example a copy installed with the skills CLI), replace the git pull with `npx skills update` run from the project where the skill was installed. If offline, continue with the current version. On any other failure, read `UPDATE.md`.
+   Skip the pip step if the libraries are pinned. Run the git pull only if `<harness-root>/.git` exists; without it (for example a copy installed with the skills CLI), `git -C` operates on an enclosing repository — run `npx skills update` from the project where the skill was installed instead. If offline, continue with the current version. On any other failure, read `UPDATE.md`.
 2. Decide the target platform before acting.
 3. For Android work, read `platforms/android/GUIDE.md`.
 4. For iOS work, read `platforms/ios/GUIDE.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Do not import local drivers directly for ordinary agent work.
    The explicit `mobilerun-core-local` and `mobilerun-sdk` entries keep those
    runtime packages upgraded even when they are already satisfied transitive
    dependencies. Agents should still import only `mobilerun_core`.
-   Skip the pip step if the libraries are pinned. If `<harness-root>` is not a git checkout (for example a copy installed with the skills CLI), replace the git pull with `npx skills update`. If offline, continue with the current version. On any other failure, read `UPDATE.md`.
+   Skip the pip step if the libraries are pinned. If `<harness-root>` is not a git checkout (for example a copy installed with the skills CLI), replace the git pull with `npx skills update` run from the project where the skill was installed. If offline, continue with the current version. On any other failure, read `UPDATE.md`.
 2. Decide the target platform before acting.
 3. For Android work, read `platforms/android/GUIDE.md`.
 4. For iOS work, read `platforms/ios/GUIDE.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Do not import local drivers directly for ordinary agent work.
    The explicit `mobilerun-core-local` and `mobilerun-sdk` entries keep those
    runtime packages upgraded even when they are already satisfied transitive
    dependencies. Agents should still import only `mobilerun_core`.
-   Skip the pip step if the libraries are pinned. Run the git pull only if `<harness-root>/.git` exists; without it (for example a copy installed with the skills CLI), `git -C` operates on an enclosing repository — run `npx skills update` from the project where the skill was installed instead. If offline, continue with the current version. On any other failure, read `UPDATE.md`.
+   If `<harness-root>/.venv` does not exist yet (a fresh clone or a fresh skills-CLI copy), skip this step and read `install.md` first. Skip the pip step if the libraries are pinned. Run the git pull only if `<harness-root>/.git` exists; without it (for example a copy installed with the skills CLI), `git -C` operates on an enclosing repository — run `npx skills update` from the project where the skill was installed instead. If offline, continue with the current version. On any other failure, read `UPDATE.md`.
 2. Decide the target platform before acting.
 3. For Android work, read `platforms/android/GUIDE.md`.
 4. For iOS work, read `platforms/ios/GUIDE.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Do not import local drivers directly for ordinary agent work.
    The explicit `mobilerun-core-local` and `mobilerun-sdk` entries keep those
    runtime packages upgraded even when they are already satisfied transitive
    dependencies. Agents should still import only `mobilerun_core`.
-   Skip the pip step if the libraries are pinned. If offline, continue with the current version. On any other failure, read `UPDATE.md`.
+   Skip the pip step if the libraries are pinned. If `<harness-root>` is not a git checkout (for example a copy installed with the skills CLI), replace the git pull with `npx skills update`. If offline, continue with the current version. On any other failure, read `UPDATE.md`.
 2. Decide the target platform before acting.
 3. For Android work, read `platforms/android/GUIDE.md`.
 4. For iOS work, read `platforms/ios/GUIDE.md`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mobile-harness
-description: Portable Android and iOS device-control harness for agents using mobilerun-core.
+description: Portable Android and iOS device-control harness for agents. Use when an agent needs to control or automate Android/iOS devices — tap, swipe, screenshot, app control — locally (ADB/Portal/Simulator) or on Mobilerun cloud devices.
 ---
 
 # mobile-harness

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -9,7 +9,11 @@ symlink, resolve the real repository path first.
 
 ## Soft Update (default)
 
-Run once per session, before platform work:
+Run once per session, before platform work. First check that
+`<harness-root>/.git` exists. If it does not (for example a copy installed
+with the skills CLI), do not run the pull — `git -C` would operate on an
+enclosing repository — and run `npx skills update` from the project where
+the skill was installed instead.
 
 ```bash
 git -C <harness-root> pull --ff-only
@@ -18,9 +22,6 @@ git -C <harness-root> pull --ff-only
 Handle the result:
 
 - Updated or already up to date: continue.
-- `not a git repository` (`<harness-root>` has no `.git`, for example a copy
-  installed with the skills CLI): run `npx skills update` from the project
-  where the skill was installed instead.
 - Offline or network failure: continue with the current version. Do not retry
   in a loop and do not report it as an error.
 - `Not possible to fast-forward`, diverged history, or local-changes errors:

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -18,6 +18,9 @@ git -C <harness-root> pull --ff-only
 Handle the result:
 
 - Updated or already up to date: continue.
+- `not a git repository` (`<harness-root>` has no `.git`, for example a copy
+  installed with the skills CLI): run `npx skills update` from the project
+  where the skill was installed instead.
 - Offline or network failure: continue with the current version. Do not retry
   in a loop and do not report it as an error.
 - `Not possible to fast-forward`, diverged history, or local-changes errors:


### PR DESCRIPTION
- `SKILL.md` description now states what the harness is and when to trigger it: control or automation of Android/iOS devices — tap, swipe, screenshot, app control — locally (ADB/Portal/Simulator) or on Mobilerun cloud devices.
- `AGENTS.md` load order and `UPDATE.md` soft update: a copy without `.git` (installed with the skills CLI) updates with `npx skills update` instead of `git pull --ff-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)