### PR TITLE
feat: add the plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "mobile-harness",
+  "description": "Portable Android and iOS device-control harness for agents. Use when an agent needs to control or automate Android/iOS devices — tap, swipe, screenshot, app control — locally (ADB/Portal/Simulator) or on Mobilerun cloud devices.",
+  "author": {
+    "name": "Droidrun",
+    "url": "https://github.com/droidrun"
+  },
+  "homepage": "https://github.com/droidrun/mobile-harness",
+  "repository": "https://github.com/droidrun/mobile-harness",
+  "license": "MIT"
+}


### PR DESCRIPTION
`.claude-plugin/plugin.json` makes the repo a valid Claude Code plugin (`claude plugin validate` passes) so it can be submitted to the community plugin marketplace. `version` is omitted deliberately: marketplace pins then track commits, and the community-marketplace CI bumps the pin automatically on new pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)